### PR TITLE
Separate welcome, roster, and ownership pages

### DIFF
--- a/0826v4/app.js
+++ b/0826v4/app.js
@@ -25,6 +25,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
+        const currentPage = document.body.dataset.page || 'welcome';
 
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {} };
@@ -51,23 +52,38 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         };
 
         // --- Event Listeners ---
-        fetchRostersButton.addEventListener('click', handleFetchRosters);
-        fetchOwnershipButton.addEventListener('click', handleFetchOwnership);
-        leagueSelect.addEventListener('change', handleLeagueSelect);
-        rosterGrid.addEventListener('click', handleTeamSelect);
-        mainContent.addEventListener('click', handleAssetClickForTrade);
-        compareButton.addEventListener('click', handleCompareClick);
-        clearCompareButton.addEventListener('click', () => handleClearCompare(true));
-        positionalViewBtn.addEventListener('click', () => setRosterView('positional'));
-        depthChartViewBtn.addEventListener('click', () => setRosterView('depth'));
-        positionalFiltersContainer.addEventListener('click', handlePositionFilter);
+        if (currentPage === 'rosters') {
+            fetchRostersButton?.addEventListener('click', handleFetchRosters);
+            fetchOwnershipButton?.addEventListener('click', () => location.href = 'ownership.html');
+        } else if (currentPage === 'ownership') {
+            fetchOwnershipButton?.addEventListener('click', handleFetchOwnership);
+            fetchRostersButton?.addEventListener('click', () => location.href = 'rosters.html');
+        } else {
+            fetchRostersButton?.addEventListener('click', () => location.href = 'rosters.html');
+            fetchOwnershipButton?.addEventListener('click', () => location.href = 'ownership.html');
+        }
+
+        leagueSelect?.addEventListener('change', handleLeagueSelect);
+        rosterGrid?.addEventListener('click', handleTeamSelect);
+        mainContent?.addEventListener('click', handleAssetClickForTrade);
+        compareButton?.addEventListener('click', handleCompareClick);
+        clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
+        positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
+        depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+        positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             setLoading(true, 'Loading initial data...');
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet() ]);
             setLoading(false);
-            welcomeScreen.classList.remove('hidden');
+            if (currentPage === 'welcome') {
+                welcomeScreen?.classList.remove('hidden');
+            } else if (currentPage === 'rosters') {
+                await handleFetchRosters();
+            } else if (currentPage === 'ownership') {
+                await handleFetchOwnership();
+            }
         });
 
         // --- View Toggling and Main Handlers ---
@@ -108,9 +124,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 state.leagues = leagues.sort((a, b) => a.name.localeCompare(b.name));
                 
                 updateButtonStates('rosters');
-                contextualControls.classList.remove('hidden');
-                playerListView.classList.add('hidden');
-                rosterView.classList.remove('hidden');
+                contextualControls?.classList.remove('hidden');
+                playerListView?.classList.add('hidden');
+                rosterView?.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
                 
                 populateLeagueSelect(state.leagues);
@@ -119,7 +135,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     leagueSelect.selectedIndex = 1;
                     await handleLeagueSelect();
                 } else {
-                    contextualControls.classList.add('hidden');
+                    contextualControls?.classList.add('hidden');
                 }
             } catch (error) {
                 handleError(error, username);
@@ -138,9 +154,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 await fetchAndSetUser(username);
                 
                 updateButtonStates('ownership');
-                contextualControls.classList.add('hidden');
-                rosterView.classList.add('hidden');
-                playerListView.classList.remove('hidden');
+                contextualControls?.classList.add('hidden');
+                rosterView?.classList.add('hidden');
+                playerListView?.classList.remove('hidden');
 
                 await renderPlayerList();
             } catch (error) {
@@ -154,7 +170,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
     hideLegend();
             const leagueId = leagueSelect.value;
             if (!leagueId || leagueId === 'Select a league...') {
-                rosterView.classList.add('hidden');
+                rosterView?.classList.add('hidden');
                 return;
             };
             
@@ -189,8 +205,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 updateCompareButtonState();
 
                 renderAllTeamData(teams);
-                
-                rosterView.classList.remove('hidden');
+
+                rosterView?.classList.remove('hidden');
 
             } catch (error) {
                 console.error(`Error loading league ${leagueId}:`, error);
@@ -1006,7 +1022,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- Utility Functions ---
         function setLoading(isLoading, message = 'Loading...') {
-            welcomeScreen.classList.add('hidden');
+            welcomeScreen?.classList.add('hidden');
             const buttons = [fetchRostersButton, fetchOwnershipButton];
             if (isLoading) {
                 loadingIndicator.textContent = message;
@@ -1020,10 +1036,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         function handleError(error, username) {
             console.error(`Error for user ${username}:`, error);
-            welcomeScreen.classList.remove('hidden');
-            rosterView.classList.add('hidden');
-            playerListView.classList.add('hidden');
-            welcomeScreen.innerHTML = `<h2 class="text-red-400">Error</h2><p>Could not fetch data for user: ${username}</p><p>${error.message}</p>`;
+            welcomeScreen?.classList.remove('hidden');
+            rosterView?.classList.add('hidden');
+            playerListView?.classList.add('hidden');
+            if (welcomeScreen) {
+                welcomeScreen.innerHTML = `<h2 class=\"text-red-400\">Error</h2><p>Could not fetch data for user: ${username}</p><p>${error.message}</p>`;
+            }
         }
 
         async function fetchWithCache(url) {

--- a/0826v4/index.html
+++ b/0826v4/index.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
   <link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
 </head>
-<body class="p-2 sm:p-4">
+<body class="p-2 sm:p-4" data-page="welcome">
 <!-- Replaced Background: Starfield -->
 <div aria-hidden="true" id="starfield">
 <div id="stars"></div>
@@ -29,37 +29,11 @@
 <header class="app-header glass-panel">
 <div class="header-row">
 <div class="username-area">
-<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text"/>
 </div>
 <div class="app-view-switcher primary-switcher">
 <button id="fetchRostersButton">Rosters</button>
 <button id="fetchOwnershipButton">Ownership %</button>
-</div>
-</div>
-<div class="hidden" id="contextual-controls">
-<div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-</div>
-<div class="header-row">
-<div id="positional-filters">
-<button class="filter-btn" data-position="QB">QB</button>
-<button class="filter-btn" data-position="RB">RB</button>
-<button class="filter-btn" data-position="WR">WR</button>
-<button class="filter-btn" data-position="TE">TE</button>
-<button class="filter-btn" data-position="FLX">FLX</button>
-</div>
-<div class="compare-controls">
-<button class="control-button" disabled="" id="compareButton">Preview</button>
-<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
-</div>
 </div>
 </div>
 </header>
@@ -182,17 +156,8 @@
 <span class="kv-right"><span class="value player-adp legend-adp">ADP</span></span>
 </div></div>
 </div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE AND ADP ARE SPECIFIC TO LEAGUE SCORING / FORMAT.</div></section>
-<div class="hidden" id="loading">Loading...</div>
-<div class="hidden" id="rosterView">
-<div id="rosterContainer">
-<div id="rosterGrid"></div>
-</div>
-</div>
-<div class="hidden" id="playerListView">
-</div>
+<div id="loading" class="hidden">Loading...</div>
 </main>
-<div id="tradeSimulator">
-</div>
 </div>
 <script defer="True" src="app.js?v=20250826235225"></script></body>
 </html>

--- a/0826v4/ownership.html
+++ b/0826v4/ownership.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Sleeper Roster & Ownership Tool</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet"/>
+<link rel="manifest" href="manifest.webmanifest?v=20250827002411?v=20250826235225"/>
+<link rel="apple-touch-icon" sizes="180x180" href="assets/icons/assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+<meta name="theme-color" content="#0D0E1B"/>
+<link rel="stylesheet" href="styles.css?v=20250827002411?v=20250826235225"/>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+<link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+<link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+</head>
+<body class="p-2 sm:p-4" data-page="ownership">
+<div aria-hidden="true" id="starfield">
+  <div id="stars"></div>
+  <div id="stars1"></div>
+  <div id="stars2"></div>
+  <div id="stars3"></div>
+</div>
+<div id="noise-overlay"></div>
+<div class="relative z-10 content-wrapper">
+  <div id="header-container">
+    <header class="app-header glass-panel">
+      <div class="header-row">
+        <div class="username-area">
+          <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text"/>
+        </div>
+        <div class="app-view-switcher primary-switcher">
+          <button id="fetchRostersButton">Rosters</button>
+          <button id="fetchOwnershipButton">Ownership %</button>
+        </div>
+      </div>
+    </header>
+  </div>
+  <main class="container mx-auto" id="content">
+    <div id="loading" class="hidden">Loading...</div>
+    <div class="hidden" id="playerListView"></div>
+  </main>
+</div>
+<script defer="True" src="app.js?v=20250826235225"></script>
+</body>
+</html>

--- a/0826v4/rosters.html
+++ b/0826v4/rosters.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Sleeper Roster &amp; Ownership Tool</title>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet"/>
+<link href="manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest"/><link rel="apple-touch-icon" sizes="180x180" href="assets/icons/assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" /><meta content="#0D0E1B" name="theme-color"/><link href="styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/><script src="https://cdn.tailwindcss.com"></script>  <link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+</head>
+<body class="p-2 sm:p-4" data-page="rosters">
+<!-- Replaced Background: Starfield -->
+<div aria-hidden="true" id="starfield">
+<div id="stars"></div>
+<div id="stars1"></div>
+<div id="stars2"></div>
+<div id="stars3"></div>
+</div>
+<div id="noise-overlay"></div>
+<!-- EDITED: Added a class for layout control -->
+<div class="relative z-10 content-wrapper">
+<div id="header-container">
+<header class="app-header glass-panel">
+<div class="header-row">
+<div class="username-area">
+<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text"/>
+</div>
+<div class="app-view-switcher primary-switcher">
+<button id="fetchRostersButton">Rosters</button>
+<button id="fetchOwnershipButton">Ownership %</button>
+</div>
+</div>
+<div class="hidden" id="contextual-controls">
+<div class="header-row">
+<div class="custom-select-wrapper">
+<select disabled="" id="leagueSelect">
+<option>Select a league...</option>
+</select>
+</div>
+<div class="view-switcher secondary-switcher">
+<button id="positionalViewBtn">Positional</button>
+<button id="depthChartViewBtn">Lineup</button>
+</div>
+</div>
+<div class="header-row">
+<div id="positional-filters">
+<button class="filter-btn" data-position="QB">QB</button>
+<button class="filter-btn" data-position="RB">RB</button>
+<button class="filter-btn" data-position="WR">WR</button>
+<button class="filter-btn" data-position="TE">TE</button>
+<button class="filter-btn" data-position="FLX">FLX</button>
+</div>
+<div class="compare-controls">
+<button class="control-button" disabled="" id="compareButton">Preview</button>
+<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+</div>
+</div>
+</div>
+</header>
+</div>
+<main class="container mx-auto" id="content">
+<div id="loading" class="hidden">Loading...</div>
+<div class="hidden" id="rosterView">
+<div id="rosterContainer">
+<div id="rosterGrid"></div>
+</div>
+</div>
+</main>
+<div id="tradeSimulator">
+</div>
+</div>
+<script defer="True" src="app.js?v=20250826235225"></script></body>
+</html>


### PR DESCRIPTION
## Summary
- Move welcome screen to standalone `index.html` and add new `rosters.html` and `ownership.html` pages
- Update `app.js` to detect the current page, wire buttons, and load the correct view
- Harden fetch handlers and loading/error utilities for missing elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea3469acc832e8500ca0e9948b9da