### PR TITLE
Separate welcome, roster, and ownership pages

### DIFF
--- a/0826v4/app.js
+++ b/0826v4/app.js
@@ -25,6 +25,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
+        const pageType = document.body.dataset.page || 'welcome';
 
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {} };
@@ -51,23 +52,59 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         };
 
         // --- Event Listeners ---
-        fetchRostersButton.addEventListener('click', handleFetchRosters);
-        fetchOwnershipButton.addEventListener('click', handleFetchOwnership);
-        leagueSelect.addEventListener('change', handleLeagueSelect);
-        rosterGrid.addEventListener('click', handleTeamSelect);
-        mainContent.addEventListener('click', handleAssetClickForTrade);
-        compareButton.addEventListener('click', handleCompareClick);
-        clearCompareButton.addEventListener('click', () => handleClearCompare(true));
-        positionalViewBtn.addEventListener('click', () => setRosterView('positional'));
-        depthChartViewBtn.addEventListener('click', () => setRosterView('depth'));
-        positionalFiltersContainer.addEventListener('click', handlePositionFilter);
+        if (pageType === 'welcome') {
+            fetchRostersButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `rosters.html?username=${encodeURIComponent(username)}`;
+            });
+            fetchOwnershipButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `ownership.html?username=${encodeURIComponent(username)}`;
+            });
+        } else if (pageType === 'rosters') {
+            fetchRostersButton?.addEventListener('click', handleFetchRosters);
+            fetchOwnershipButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `ownership.html?username=${encodeURIComponent(username)}`;
+            });
+        } else if (pageType === 'ownership') {
+            fetchOwnershipButton?.addEventListener('click', handleFetchOwnership);
+            fetchRostersButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `rosters.html?username=${encodeURIComponent(username)}`;
+            });
+        }
+
+        leagueSelect?.addEventListener('change', handleLeagueSelect);
+        rosterGrid?.addEventListener('click', handleTeamSelect);
+        mainContent?.addEventListener('click', handleAssetClickForTrade);
+        compareButton?.addEventListener('click', handleCompareClick);
+        clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
+        positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
+        depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+        positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             setLoading(true, 'Loading initial data...');
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet() ]);
             setLoading(false);
-            welcomeScreen.classList.remove('hidden');
+            if (welcomeScreen) welcomeScreen.classList.remove('hidden');
+
+            const params = new URLSearchParams(window.location.search);
+            const uname = params.get('username');
+            if (uname) {
+                usernameInput.value = uname;
+                if (pageType === 'rosters') {
+                    await handleFetchRosters();
+                } else if (pageType === 'ownership') {
+                    await handleFetchOwnership();
+                }
+            }
         });
 
         // --- View Toggling and Main Handlers ---
@@ -1006,8 +1043,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- Utility Functions ---
         function setLoading(isLoading, message = 'Loading...') {
-            welcomeScreen.classList.add('hidden');
-            const buttons = [fetchRostersButton, fetchOwnershipButton];
+            welcomeScreen?.classList.add('hidden');
+            const buttons = [fetchRostersButton, fetchOwnershipButton].filter(Boolean);
             if (isLoading) {
                 loadingIndicator.textContent = message;
                 loadingIndicator.classList.remove('hidden');
@@ -1020,10 +1057,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         function handleError(error, username) {
             console.error(`Error for user ${username}:`, error);
-            welcomeScreen.classList.remove('hidden');
-            rosterView.classList.add('hidden');
-            playerListView.classList.add('hidden');
-            welcomeScreen.innerHTML = `<h2 class="text-red-400">Error</h2><p>Could not fetch data for user: ${username}</p><p>${error.message}</p>`;
+            if (welcomeScreen) {
+                welcomeScreen.classList.remove('hidden');
+                welcomeScreen.innerHTML = `<h2 class="text-red-400">Error</h2><p>Could not fetch data for user: ${username}</p><p>${error.message}</p>`;
+            }
+            rosterView?.classList.add('hidden');
+            playerListView?.classList.add('hidden');
         }
 
         async function fetchWithCache(url) {

--- a/0826v4/ownership.html
+++ b/0826v4/ownership.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
   <link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
 </head>
-<body data-page="welcome" class="p-2 sm:p-4">
+<body data-page="ownership" class="p-2 sm:p-4">
 <!-- Replaced Background: Starfield -->
 <div aria-hidden="true" id="starfield">
 <div id="stars"></div>
@@ -36,108 +36,36 @@
 <button id="fetchOwnershipButton">Ownership %</button>
 </div>
 </div>
-<!-- contextual controls removed on welcome page -->
+<div class="hidden" id="contextual-controls">
+<div class="header-row">
+<div class="custom-select-wrapper">
+<select disabled="" id="leagueSelect">
+<option>Select a league...</option>
+</select>
+</div>
+<div class="view-switcher secondary-switcher">
+<button id="positionalViewBtn">Positional</button>
+<button id="depthChartViewBtn">Lineup</button>
+</div>
+</div>
+<div class="header-row">
+<div id="positional-filters">
+<button class="filter-btn" data-position="QB">QB</button>
+<button class="filter-btn" data-position="RB">RB</button>
+<button class="filter-btn" data-position="WR">WR</button>
+<button class="filter-btn" data-position="TE">TE</button>
+<button class="filter-btn" data-position="FLX">FLX</button>
+</div>
+<div class="compare-controls">
+<button class="control-button" disabled="" id="compareButton">Preview</button>
+<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+</div>
+</div>
+</div>
 </header>
 </div>
 <main class="container mx-auto" id="content">
-<div id="welcome-screen">
-<picture class="welcome-logo">
-  <img 
-    alt="App logo" 
-    decoding="async" 
-    height="128" 
-    loading="eager" 
-    width="128"
-    src="assets/welcome/welcome-logo-256.png"
-    style="
-      -webkit-mask-image: 
-      radial-gradient(circle at 59% 59%, rgba(0,0,0,1) 42%, rgba(0,0,0,0) 89%);
-      mask-image: 
-      radial-gradient(circle at 59% 59%, rgba(0,0,0,1) 42%, rgba(0,0,0,0) 89%);
-      -webkit-mask-repeat: no-repeat;
-      mask-repeat: no-repeat;
-      -webkit-mask-size: 100% 100%;
-      mask-size: 100% 100%;
-          "
-  />
-</picture>
-
-<h2>Welcome to the Sleeper Tool</h2>
-<p>
-  Enter a Sleeper username and click 'Rosters' or 'Ownership %' to get started.
-</p>
-
-<section 
-  aria-label="Install as a web app" 
-  class="panel install-panel" 
-  id="install-webapp"
->
-  <h3 class="panel-title">Set up as a Web App</h3>
-
-  <details class="install-details">
-    <summary>iPhone, iPad, Android, and Mac</summary>
-
-    <div class="install-columns">
-
-      <div class="install-card">
-        <h4>iPhone (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Tap Share.</li>
-          <li>Scroll and tap Add to Home Screen.</li>
-        </ol>
-        <p class="hint">
-          Tip: If you don't see it, tap Edit Actions and enable Add to Home Screen.
-        </p>
-      </div>
-
-      <div class="install-card">
-        <h4>iPad (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Tap Share in the toolbar.</li>
-          <li>Tap Add to Home Screen.</li>
-        </ol>
-      </div>
-
-      <div class="install-card">
-        <h4>Android (Chrome)</h4>
-        <ol>
-          <li>Open this site in Chrome.</li>
-          <li>Tap the ⋮ menu.</li>
-          <li>Choose Add to Home screen or Install app.</li>
-        </ol>
-      </div>
-
-      <div class="install-card">
-        <h4>Mac (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Choose File → Add to Dock (or Share → Add to Dock).</li>
-        </ol>
-      </div>
-
-    </div>
-  </details>
-</section>
-<!-- hidden SVG mask for the glow -->
-<svg width="0" height="0" style="position:absolute;left:-9999px;top:-9999px" aria-hidden="true">
-  <defs>
-    <!-- Upside-down T made from two rounded rects -->
-    <mask id="welcomeGlowT" maskUnits="objectBoundingBox">
-      <!-- Black = transparent (hide), White = visible (show glow) -->
-      <rect x="0" y="0" width="1" height="1" fill="black"/>
-      <!-- Horizontal bar (near bottom) -->
-      <rect x="0.11" y="0.80" width="0.78" height="0.16" rx="0.08" ry="0.08" fill="white"/>
-      <!-- Vertical stem (centered) -->
-      <rect x="0.39" y="0.10" width="0.22" height="0.70" rx="0.08" ry="0.08" fill="white"/>
-    </mask>
-  </defs>
-</svg>
-
-
-<!-- External footnote (below card) -->
-</div><section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
+<section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
 <!-- Top row: Position tag + Player  -->
 <div class="player-main-line legend-main">
 <span class="player-tag legend-pos">POSITION</span>
@@ -158,7 +86,16 @@
 </div></div>
 </div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE AND ADP ARE SPECIFIC TO LEAGUE SCORING / FORMAT.</div></section>
 <div class="hidden" id="loading">Loading...</div>
-</main>
+<div class="hidden" id="rosterView">
+<div id="rosterContainer">
+<div id="rosterGrid"></div>
 </div>
-<script defer src="app.js?v=20250826235225"></script></body>
+</div>
+<div class="hidden" id="playerListView">
+</div>
+</main>
+<div id="tradeSimulator">
+</div>
+</div>
+<script defer="True" src="app.js?v=20250826235225"></script></body>
 </html>

--- a/0826v4/rosters.html
+++ b/0826v4/rosters.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
   <link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
 </head>
-<body data-page="welcome" class="p-2 sm:p-4">
+<body data-page="rosters" class="p-2 sm:p-4">
 <!-- Replaced Background: Starfield -->
 <div aria-hidden="true" id="starfield">
 <div id="stars"></div>
@@ -36,108 +36,36 @@
 <button id="fetchOwnershipButton">Ownership %</button>
 </div>
 </div>
-<!-- contextual controls removed on welcome page -->
+<div class="hidden" id="contextual-controls">
+<div class="header-row">
+<div class="custom-select-wrapper">
+<select disabled="" id="leagueSelect">
+<option>Select a league...</option>
+</select>
+</div>
+<div class="view-switcher secondary-switcher">
+<button id="positionalViewBtn">Positional</button>
+<button id="depthChartViewBtn">Lineup</button>
+</div>
+</div>
+<div class="header-row">
+<div id="positional-filters">
+<button class="filter-btn" data-position="QB">QB</button>
+<button class="filter-btn" data-position="RB">RB</button>
+<button class="filter-btn" data-position="WR">WR</button>
+<button class="filter-btn" data-position="TE">TE</button>
+<button class="filter-btn" data-position="FLX">FLX</button>
+</div>
+<div class="compare-controls">
+<button class="control-button" disabled="" id="compareButton">Preview</button>
+<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+</div>
+</div>
+</div>
 </header>
 </div>
 <main class="container mx-auto" id="content">
-<div id="welcome-screen">
-<picture class="welcome-logo">
-  <img 
-    alt="App logo" 
-    decoding="async" 
-    height="128" 
-    loading="eager" 
-    width="128"
-    src="assets/welcome/welcome-logo-256.png"
-    style="
-      -webkit-mask-image: 
-      radial-gradient(circle at 59% 59%, rgba(0,0,0,1) 42%, rgba(0,0,0,0) 89%);
-      mask-image: 
-      radial-gradient(circle at 59% 59%, rgba(0,0,0,1) 42%, rgba(0,0,0,0) 89%);
-      -webkit-mask-repeat: no-repeat;
-      mask-repeat: no-repeat;
-      -webkit-mask-size: 100% 100%;
-      mask-size: 100% 100%;
-          "
-  />
-</picture>
-
-<h2>Welcome to the Sleeper Tool</h2>
-<p>
-  Enter a Sleeper username and click 'Rosters' or 'Ownership %' to get started.
-</p>
-
-<section 
-  aria-label="Install as a web app" 
-  class="panel install-panel" 
-  id="install-webapp"
->
-  <h3 class="panel-title">Set up as a Web App</h3>
-
-  <details class="install-details">
-    <summary>iPhone, iPad, Android, and Mac</summary>
-
-    <div class="install-columns">
-
-      <div class="install-card">
-        <h4>iPhone (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Tap Share.</li>
-          <li>Scroll and tap Add to Home Screen.</li>
-        </ol>
-        <p class="hint">
-          Tip: If you don't see it, tap Edit Actions and enable Add to Home Screen.
-        </p>
-      </div>
-
-      <div class="install-card">
-        <h4>iPad (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Tap Share in the toolbar.</li>
-          <li>Tap Add to Home Screen.</li>
-        </ol>
-      </div>
-
-      <div class="install-card">
-        <h4>Android (Chrome)</h4>
-        <ol>
-          <li>Open this site in Chrome.</li>
-          <li>Tap the ⋮ menu.</li>
-          <li>Choose Add to Home screen or Install app.</li>
-        </ol>
-      </div>
-
-      <div class="install-card">
-        <h4>Mac (Safari)</h4>
-        <ol>
-          <li>Open this site in Safari.</li>
-          <li>Choose File → Add to Dock (or Share → Add to Dock).</li>
-        </ol>
-      </div>
-
-    </div>
-  </details>
-</section>
-<!-- hidden SVG mask for the glow -->
-<svg width="0" height="0" style="position:absolute;left:-9999px;top:-9999px" aria-hidden="true">
-  <defs>
-    <!-- Upside-down T made from two rounded rects -->
-    <mask id="welcomeGlowT" maskUnits="objectBoundingBox">
-      <!-- Black = transparent (hide), White = visible (show glow) -->
-      <rect x="0" y="0" width="1" height="1" fill="black"/>
-      <!-- Horizontal bar (near bottom) -->
-      <rect x="0.11" y="0.80" width="0.78" height="0.16" rx="0.08" ry="0.08" fill="white"/>
-      <!-- Vertical stem (centered) -->
-      <rect x="0.39" y="0.10" width="0.22" height="0.70" rx="0.08" ry="0.08" fill="white"/>
-    </mask>
-  </defs>
-</svg>
-
-
-<!-- External footnote (below card) -->
-</div><section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
+<section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
 <!-- Top row: Position tag + Player  -->
 <div class="player-main-line legend-main">
 <span class="player-tag legend-pos">POSITION</span>
@@ -158,7 +86,16 @@
 </div></div>
 </div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE AND ADP ARE SPECIFIC TO LEAGUE SCORING / FORMAT.</div></section>
 <div class="hidden" id="loading">Loading...</div>
-</main>
+<div class="hidden" id="rosterView">
+<div id="rosterContainer">
+<div id="rosterGrid"></div>
 </div>
-<script defer src="app.js?v=20250826235225"></script></body>
+</div>
+<div class="hidden" id="playerListView">
+</div>
+</main>
+<div id="tradeSimulator">
+</div>
+</div>
+<script defer="True" src="app.js?v=20250826235225"></script></body>
 </html>


### PR DESCRIPTION
## Summary
- Create dedicated `index.html`, `rosters.html`, and `ownership.html` pages
- Update app logic to route between pages and auto-fetch data based on query parameters
- Harden loading/error helpers for missing elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea3469acc832e8500ca0e9948b9da